### PR TITLE
Feature/jng 2930 action group for tables

### DIFF
--- a/lib/src/judo_app_bar_popup_button.dart
+++ b/lib/src/judo_app_bar_popup_button.dart
@@ -25,7 +25,7 @@ class JudoAppBarPopupButton<T> extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: padding,
+      padding: padding == null ? EdgeInsets.all(0) : padding,
       child: JudoPopupButtonWidget(
         label: label,
         loadingState: loadingState,

--- a/lib/src/judo_popup_button_widget.dart
+++ b/lib/src/judo_popup_button_widget.dart
@@ -62,6 +62,7 @@ class JudoPopupButtonWidget<T> extends StatelessWidget {
       context: context,
       items: getItemBuilder(context).call(context),
       position: position,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(4.0))),
 
       /// "The `useRootNavigator` argument is used to determine whether to push the
       /// menu to the [Navigator] furthest from or nearest to the given `context`. It

--- a/lib/src/judo_selector_table.dart
+++ b/lib/src/judo_selector_table.dart
@@ -76,7 +76,7 @@ class JudoSelectorTable extends StatelessWidget {
               showCheckboxColumn: true,
               sortAscending: sortAscending == null ? true : sortAscending,
               sortColumnIndex: sortColumnIndex,
-              columns: dataInfo.getColumns(onAdd, onSort, null),
+              columns: dataInfo.getColumns(onAdd, onSort),
               rows: dataRow(context),
               dataRowHeight: JudoComponentCustomizer.get().getLineHeight(),
           ),

--- a/lib/src/judo_selector_table.dart
+++ b/lib/src/judo_selector_table.dart
@@ -76,7 +76,7 @@ class JudoSelectorTable extends StatelessWidget {
               showCheckboxColumn: true,
               sortAscending: sortAscending == null ? true : sortAscending,
               sortColumnIndex: sortColumnIndex,
-              columns: dataInfo.getColumns(onAdd, onSort),
+              columns: dataInfo.getColumns(onAdd, onSort, null),
               rows: dataRow(context),
               dataRowHeight: JudoComponentCustomizer.get().getLineHeight(),
           ),

--- a/lib/src/judo_table.dart
+++ b/lib/src/judo_table.dart
@@ -162,7 +162,7 @@ class JudoTable extends StatelessWidget {
     return JudoAppBarPopupButton<int>(
       icon: Icon(Icons.more_vert),
       items: tableActions,
-      outlined: true,
+      outlined: false,
       padding: EdgeInsets.all(0),
     );
   }

--- a/lib/src/judo_table.dart
+++ b/lib/src/judo_table.dart
@@ -34,7 +34,7 @@ class JudoTable extends StatelessWidget {
     this.inCard = false,
     this.alignment = Alignment.centerLeft,
     this.sortInitially = false,
-    this.tableActions,
+    this.tableActions = const <int, JudoMenuItemData>{},
   }) : super(key: key);
 
   final double col;
@@ -57,7 +57,7 @@ class JudoTable extends StatelessWidget {
   final EdgeInsets padding;
   final bool inCard;
   final bool sortInitially;
-  final Map<int, JudoMenuItemData> tableActions = Map<int, JudoMenuItemData>();
+  final Map<int, JudoMenuItemData> tableActions;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/judo_table.dart
+++ b/lib/src/judo_table.dart
@@ -1,7 +1,7 @@
 part of judo.components;
 
 abstract class JudoTableDataInfo {
-  List<DataColumn> getColumns(Function onAdd, DataColumnSortCallback onSort, Widget popupActions);
+  List<DataColumn> getColumns(Function onAdd, DataColumnSortCallback onSort);
   Function getRow({BuildContext context,
     Function navigateToEditPageAction,
     Function navigateToViewPageAction,
@@ -94,7 +94,8 @@ class JudoTable extends StatelessWidget {
         showCheckboxColumn: false,
         sortAscending: _shouldSortAscending(),
         sortColumnIndex: sortColumnIndex,
-        columns: dataInfo.getColumns(onAdd, onSort, getPopupButton()),
+        columns: tableActions == null || tableActions.isEmpty ?
+          dataInfo.getColumns(onAdd, onSort) : getColumns(),
         rows: dataRow(context),
         dataRowHeight: JudoComponentCustomizer.get().getLineHeight(),
         headingRowHeight: JudoComponentCustomizer.get().getLineHeight(),
@@ -149,6 +150,12 @@ class JudoTable extends StatelessWidget {
   
   bool _shouldSortAscending() {
     return sortAscending == null ? true : sortAscending;
+  }
+
+  List<DataColumn> getColumns() {
+    List<DataColumn> cols = dataInfo.getColumns(onAdd, onSort);
+    cols.add(DataColumn(label: getPopupButton()));
+    return cols;
   }
 
   JudoAppBarPopupButton getPopupButton() {

--- a/lib/src/judo_table.dart
+++ b/lib/src/judo_table.dart
@@ -57,7 +57,7 @@ class JudoTable extends StatelessWidget {
   final EdgeInsets padding;
   final bool inCard;
   final bool sortInitially;
-  final Map<int, JudoMenuItemData> tableActions;
+  final Map<int, JudoMenuItemData> tableActions = Map<int, JudoMenuItemData>();
 
   @override
   Widget build(BuildContext context) {
@@ -94,7 +94,7 @@ class JudoTable extends StatelessWidget {
         showCheckboxColumn: false,
         sortAscending: _shouldSortAscending(),
         sortColumnIndex: sortColumnIndex,
-        columns: tableActions == null || tableActions.isEmpty ?
+        columns: tableActions.isEmpty ?
           dataInfo.getColumns(onAdd, onSort) : getColumns(),
         rows: dataRow(context),
         dataRowHeight: JudoComponentCustomizer.get().getLineHeight(),

--- a/lib/src/judo_table.dart
+++ b/lib/src/judo_table.dart
@@ -1,7 +1,7 @@
 part of judo.components;
 
 abstract class JudoTableDataInfo {
-  List<DataColumn> getColumns(Function onAdd, DataColumnSortCallback onSort);
+  List<DataColumn> getColumns(Function onAdd, DataColumnSortCallback onSort, Widget popupActions);
   Function getRow({BuildContext context,
     Function navigateToEditPageAction,
     Function navigateToViewPageAction,
@@ -34,6 +34,7 @@ class JudoTable extends StatelessWidget {
     this.inCard = false,
     this.alignment = Alignment.centerLeft,
     this.sortInitially = false,
+    this.tableActions,
   }) : super(key: key);
 
   final double col;
@@ -56,6 +57,7 @@ class JudoTable extends StatelessWidget {
   final EdgeInsets padding;
   final bool inCard;
   final bool sortInitially;
+  final Map<int, JudoMenuItemData> tableActions;
 
   @override
   Widget build(BuildContext context) {
@@ -92,7 +94,7 @@ class JudoTable extends StatelessWidget {
         showCheckboxColumn: false,
         sortAscending: _shouldSortAscending(),
         sortColumnIndex: sortColumnIndex,
-        columns: dataInfo.getColumns(onAdd, onSort),
+        columns: dataInfo.getColumns(onAdd, onSort, getPopupButton()),
         rows: dataRow(context),
         dataRowHeight: JudoComponentCustomizer.get().getLineHeight(),
         headingRowHeight: JudoComponentCustomizer.get().getLineHeight(),
@@ -147,5 +149,14 @@ class JudoTable extends StatelessWidget {
   
   bool _shouldSortAscending() {
     return sortAscending == null ? true : sortAscending;
+  }
+
+  JudoAppBarPopupButton getPopupButton() {
+    return JudoAppBarPopupButton<int>(
+      icon: Icon(Icons.more_vert),
+      items: tableActions,
+      outlined: true,
+      padding: EdgeInsets.all(0),
+    );
   }
 }

--- a/lib/src/judo_table.dart
+++ b/lib/src/judo_table.dart
@@ -94,8 +94,7 @@ class JudoTable extends StatelessWidget {
         showCheckboxColumn: false,
         sortAscending: _shouldSortAscending(),
         sortColumnIndex: sortColumnIndex,
-        columns: tableActions.isEmpty ?
-          dataInfo.getColumns(onAdd, onSort) : getColumns(),
+        columns: tableActions.isEmpty ? dataInfo.getColumns(onAdd, onSort) : [...dataInfo.getColumns(onAdd, onSort), DataColumn(label: getPopupButton())],
         rows: dataRow(context),
         dataRowHeight: JudoComponentCustomizer.get().getLineHeight(),
         headingRowHeight: JudoComponentCustomizer.get().getLineHeight(),
@@ -150,12 +149,6 @@ class JudoTable extends StatelessWidget {
   
   bool _shouldSortAscending() {
     return sortAscending == null ? true : sortAscending;
-  }
-
-  List<DataColumn> getColumns() {
-    List<DataColumn> cols = dataInfo.getColumns(onAdd, onSort);
-    cols.add(DataColumn(label: getPopupButton()));
-    return cols;
   }
 
   JudoAppBarPopupButton getPopupButton() {


### PR DESCRIPTION
A new attribute (tableActions) is added to the table widget, which is used to create the popup action button in the header cell of the last  column.
The shape of the popup menu is changed to a slightly rounded rectangle for a more satisfying visual experience.