### PR TITLE
JNG-3043: on blur support

### DIFF
--- a/lib/src/judo_date_input.dart
+++ b/lib/src/judo_date_input.dart
@@ -55,7 +55,7 @@ class _JudoDateInputState extends State<JudoDateInput> {
   }
 
   @override
-  void didUpdateWidget(JudoInputText oldWidget) {
+  void didUpdateWidget(JudoDateInput oldWidget) {
     super.didUpdateWidget(oldWidget); // placement of this is SUPER IMPORTANT!
     if (controller.text != widget.initialDate) {
       controller.text = widget.initialDate != null ? formatter.format(widget.initialDate) : null;

--- a/lib/src/judo_date_input.dart
+++ b/lib/src/judo_date_input.dart
@@ -55,6 +55,14 @@ class _JudoDateInputState extends State<JudoDateInput> {
   }
 
   @override
+  void didUpdateWidget(JudoInputText oldWidget) {
+    super.didUpdateWidget(oldWidget); // placement of this is SUPER IMPORTANT!
+    if (controller.text != widget.initialDate) {
+      controller.text = widget.initialDate != null ? formatter.format(widget.initialDate) : null;
+    }
+  }
+
+  @override
   void dispose() {
     controller.dispose();
     super.dispose();

--- a/lib/src/judo_date_time_input.dart
+++ b/lib/src/judo_date_time_input.dart
@@ -57,6 +57,14 @@ class _JudoDateTimeInputState extends State<JudoDateTimeInput> {
   }
 
   @override
+  void didUpdateWidget(JudoInputText oldWidget) {
+    super.didUpdateWidget(oldWidget); // placement of this is SUPER IMPORTANT!
+    if (controller.text != widget.initialDate) {
+      controller.text = widget.initialDate != null ? formatter.format(widget.initialDate) : null;
+    }
+  }
+
+  @override
   void dispose() {
     controller.dispose();
     super.dispose();

--- a/lib/src/judo_date_time_input.dart
+++ b/lib/src/judo_date_time_input.dart
@@ -57,7 +57,7 @@ class _JudoDateTimeInputState extends State<JudoDateTimeInput> {
   }
 
   @override
-  void didUpdateWidget(JudoInputText oldWidget) {
+  void didUpdateWidget(JudoDateTimeInput oldWidget) {
     super.didUpdateWidget(oldWidget); // placement of this is SUPER IMPORTANT!
     if (controller.text != widget.initialDate) {
       controller.text = widget.initialDate != null ? formatter.format(widget.initialDate) : null;

--- a/lib/src/judo_input_text.dart
+++ b/lib/src/judo_input_text.dart
@@ -53,14 +53,6 @@ class JudoInputTextState extends State<JudoInputText> {
   final FocusNode focusNode = FocusNode();
 
   @override
-  void didUpdateWidget(JudoInputText oldWidget) {
-    super.didUpdateWidget(oldWidget); // placement of this is SUPER IMPORTANT!
-    if (controller.text != widget.initialValue) {
-      controller.text = widget.initialValue;
-    }
-  }
-
-  @override
   void initState() {
     super.initState();
     controller.text = widget.initialValue;
@@ -73,6 +65,14 @@ class JudoInputTextState extends State<JudoInputText> {
           widget.onBlur();
         }
       });
+    }
+  }
+
+  @override
+  void didUpdateWidget(JudoInputText oldWidget) {
+    super.didUpdateWidget(oldWidget); // placement of this is SUPER IMPORTANT!
+    if (controller.text != widget.initialValue) {
+      controller.text = widget.initialValue;
     }
   }
 

--- a/lib/src/judo_input_text.dart
+++ b/lib/src/judo_input_text.dart
@@ -9,6 +9,8 @@ class JudoInputText extends StatefulWidget {
     this.label,
     this.icon,
     this.onChanged,
+    this.onFocus,
+    this.onBlur,
     this.onSubmitted,
     this.errorMessage,
     this.initialValue,
@@ -28,6 +30,8 @@ class JudoInputText extends StatefulWidget {
   final String label;
   final Icon icon;
   final Function onChanged;
+  final Function onFocus;
+  final Function onBlur;
   final Function onSubmitted;
   final String errorMessage;
   final String initialValue;
@@ -46,11 +50,30 @@ class JudoInputText extends StatefulWidget {
 
 class JudoInputTextState extends State<JudoInputText> {
   final TextEditingController controller = TextEditingController();
+  final FocusNode focusNode = FocusNode();
+
+  @override
+  void didUpdateWidget(JudoInputText oldWidget) {
+    super.didUpdateWidget(oldWidget); // placement of this is SUPER IMPORTANT!
+    if (controller.text != widget.initialValue) {
+      controller.text = widget.initialValue;
+    }
+  }
 
   @override
   void initState() {
     super.initState();
     controller.text = widget.initialValue;
+
+    if (widget.onFocus != null || widget.onBlur != null) {
+      focusNode.addListener(() {
+        if (focusNode.hasFocus && widget.onFocus != null) {
+          widget.onFocus();
+        } else if (!focusNode.hasFocus && widget.onBlur != null) {
+          widget.onBlur();
+        }
+      });
+    }
   }
 
   @override
@@ -87,6 +110,7 @@ class JudoInputTextState extends State<JudoInputText> {
               decoration: JudoComponentCustomizer.get().getInputTextDecoration(theme, widget.label, widget.icon, null, widget.mandatory, widget.multiline, widget.errorMessage),
               onChanged: widget.onChanged,
               onSubmitted: widget.onSubmitted,
+              focusNode: focusNode,
             ),
           decoration: widget.errorMessage != null ? null : JudoComponentCustomizer.get().getInputBoxCustomizer(widget.disabled, widget.readOnly),
         ),

--- a/lib/src/judo_input_text.dart
+++ b/lib/src/judo_input_text.dart
@@ -51,6 +51,7 @@ class JudoInputText extends StatefulWidget {
 class JudoInputTextState extends State<JudoInputText> {
   final TextEditingController controller = TextEditingController();
   final FocusNode focusNode = FocusNode();
+  bool _focused = false;
 
   @override
   void initState() {
@@ -58,13 +59,22 @@ class JudoInputTextState extends State<JudoInputText> {
     controller.text = widget.initialValue;
 
     if (widget.onFocus != null || widget.onBlur != null) {
-      focusNode.addListener(() {
-        if (focusNode.hasFocus && widget.onFocus != null) {
-          widget.onFocus();
-        } else if (!focusNode.hasFocus && widget.onBlur != null) {
-          widget.onBlur();
-        }
+      focusNode.addListener(_focusHandler);
+    }
+  }
+
+  void _focusHandler() {
+    // According to docs, focus is lost on node every time a build happens, so we
+    // store it locally, and only trigger handlers where there is an actual change
+    if (focusNode.hasFocus != _focused) {
+      this.setState(() {
+        _focused = focusNode.hasFocus;
       });
+      if (_focused && widget.onFocus != null) {
+        widget.onFocus();
+      } else if (!_focused && widget.onBlur != null) {
+        widget.onBlur();
+      }
     }
   }
 

--- a/lib/src/judo_numeric_input.dart
+++ b/lib/src/judo_numeric_input.dart
@@ -49,6 +49,7 @@ class _JudoNumericInputState extends State<JudoNumericInput> {
   RegExp _regExp = RegExp(r"^[+|\-]{0,1}\d*\.{0,1}\d*$");
   final TextEditingController controller = TextEditingController();
   final FocusNode focusNode = FocusNode();
+  bool _focused = false;
 
   @override
   void initState() {
@@ -56,13 +57,22 @@ class _JudoNumericInputState extends State<JudoNumericInput> {
     controller.text = widget.initialValue;
 
     if (widget.onFocus != null || widget.onBlur != null) {
-      focusNode.addListener(() {
-        if (focusNode.hasFocus && widget.onFocus != null) {
-          widget.onFocus();
-        } else if (!focusNode.hasFocus && widget.onBlur != null) {
-          widget.onBlur();
-        }
+      focusNode.addListener(_focusHandler);
+    }
+  }
+
+  void _focusHandler() {
+    // According to docs, focus is lost on node every time a build happens, so we
+    // store it locally, and only trigger handlers where there is an actual change
+    if (focusNode.hasFocus != _focused) {
+      this.setState(() {
+        _focused = focusNode.hasFocus;
       });
+      if (_focused && widget.onFocus != null) {
+        widget.onFocus();
+      } else if (!_focused && widget.onBlur != null) {
+        widget.onBlur();
+      }
     }
   }
 

--- a/lib/src/judo_numeric_input.dart
+++ b/lib/src/judo_numeric_input.dart
@@ -52,6 +52,14 @@ class _JudoNumericInputState extends State<JudoNumericInput> {
   }
 
   @override
+  void didUpdateWidget(JudoInputText oldWidget) {
+    super.didUpdateWidget(oldWidget); // placement of this is SUPER IMPORTANT!
+    if (controller.text != widget.initialValue) {
+      controller.text = widget.initialValue;
+    }
+  }
+
+  @override
   void dispose() {
     controller.dispose();
     super.dispose();

--- a/lib/src/judo_numeric_input.dart
+++ b/lib/src/judo_numeric_input.dart
@@ -67,7 +67,7 @@ class _JudoNumericInputState extends State<JudoNumericInput> {
   }
 
   @override
-  void didUpdateWidget(JudoInputText oldWidget) {
+  void didUpdateWidget(JudoNumericInput oldWidget) {
     super.didUpdateWidget(oldWidget); // placement of this is SUPER IMPORTANT!
     if (controller.text != widget.initialValue) {
       controller.text = widget.initialValue;

--- a/lib/src/judo_numeric_input.dart
+++ b/lib/src/judo_numeric_input.dart
@@ -10,6 +10,8 @@ class JudoNumericInput extends StatefulWidget {
     this.label,
     this.icon,
     this.onChanged,
+    this.onFocus,
+    this.onBlur,
     this.onSubmitted,
     this.errorMessage,
     this.initialValue,
@@ -27,6 +29,8 @@ class JudoNumericInput extends StatefulWidget {
   final String label;
   final Icon icon;
   final Function onChanged;
+  final Function onFocus;
+  final Function onBlur;
   final Function onSubmitted;
   final String errorMessage;
   final String initialValue;
@@ -44,11 +48,22 @@ class JudoNumericInput extends StatefulWidget {
 class _JudoNumericInputState extends State<JudoNumericInput> {
   RegExp _regExp = RegExp(r"^[+|\-]{0,1}\d*\.{0,1}\d*$");
   final TextEditingController controller = TextEditingController();
+  final FocusNode focusNode = FocusNode();
 
   @override
   void initState() {
     super.initState();
     controller.text = widget.initialValue;
+
+    if (widget.onFocus != null || widget.onBlur != null) {
+      focusNode.addListener(() {
+        if (focusNode.hasFocus && widget.onFocus != null) {
+          widget.onFocus();
+        } else if (!focusNode.hasFocus && widget.onBlur != null) {
+          widget.onBlur();
+        }
+      });
+    }
   }
 
   @override
@@ -100,6 +115,7 @@ class _JudoNumericInputState extends State<JudoNumericInput> {
                 return widget.onChanged(value);
             },
             onSubmitted: widget.onSubmitted,
+            focusNode: focusNode,
           ),
         ),
       ),

--- a/lib/src/judo_time_input.dart
+++ b/lib/src/judo_time_input.dart
@@ -49,7 +49,7 @@ class _JudoTimeInputState extends State<JudoTimeInput> {
   void didUpdateWidget(JudoTimeInput oldWidget) {
     super.didUpdateWidget(oldWidget); // placement of this is SUPER IMPORTANT!
     if (controller.text != widget.initialDate) {
-      controller.text = widget.initialDate != null ? formatter.format(widget.initialDate) : null;
+      controller.text = widget.initialDate != null ? widget.initialDate.toString() : null;
     }
   }
 

--- a/lib/src/judo_time_input.dart
+++ b/lib/src/judo_time_input.dart
@@ -46,7 +46,7 @@ class _JudoTimeInputState extends State<JudoTimeInput> {
   }
 
   @override
-  void didUpdateWidget(JudoInputText oldWidget) {
+  void didUpdateWidget(JudoTimeInput oldWidget) {
     super.didUpdateWidget(oldWidget); // placement of this is SUPER IMPORTANT!
     if (controller.text != widget.initialDate) {
       controller.text = widget.initialDate != null ? formatter.format(widget.initialDate) : null;

--- a/lib/src/judo_time_input.dart
+++ b/lib/src/judo_time_input.dart
@@ -46,6 +46,14 @@ class _JudoTimeInputState extends State<JudoTimeInput> {
   }
 
   @override
+  void didUpdateWidget(JudoInputText oldWidget) {
+    super.didUpdateWidget(oldWidget); // placement of this is SUPER IMPORTANT!
+    if (controller.text != widget.initialDate) {
+      controller.text = widget.initialDate != null ? formatter.format(widget.initialDate) : null;
+    }
+  }
+
+  @override
   void dispose() {
     controller.dispose();
     super.dispose();


### PR DESCRIPTION
Components which were not able to detect incoming changes have been fixed.
Keyboard input type widgets received an `onBlur()` callback, so that users can define callbacks for finalized changes
Fixed focus in-out handling.