### PR TITLE
[WIP] JNG-3123: support numeric input mask

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ app.*.symbols
 
 # Obfuscation related
 app.*.map.json
+.flutter
+

--- a/flutterw
+++ b/flutterw
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+if [ ! -d ".flutter" ] 
+then
+    echo "Flutter not installed locally, installing..." 
+    wget https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_2.5.1-stable.tar.xz
+    mkdir .flutter
+    tar xf ./flutter_linux_2.5.1-stable.tar.xz --strip-components=1 -C .flutter
+    rm ./flutter_linux_2.5.1-stable.tar.xz
+
+    echo "Running: flutter precache..."
+    .flutter/bin/flutter precache
+
+    echo "Running: flutter devices..."
+    .flutter/bin/flutter devices
+
+    echo "Flutter installed successfully under ./flutter!"
+fi
+
+.flutter/bin/flutter "$@"

--- a/lib/src/package.dart
+++ b/lib/src/package.dart
@@ -11,6 +11,7 @@ import 'package:intl/intl.dart';
 import 'package:mobx/mobx.dart';
 import 'package:flutter/services.dart';
 import 'state_handling/package.dart';
+import 'package:mask_text_input_formatter/mask_text_input_formatter.dart';
 
 export 'state_handling/package.dart';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,7 @@ dependencies:
   intl: ^0.17.0
   mobx: ^1.2.1+4
   flutter_mobx: ^1.1.0+2
+  mask_text_input_formatter: ^2.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
The `inputFormatters` list has been modified, because current formatter MUST not conflict with an inputmask if the later has been provided.