### PR TITLE
JNG-3168: make readOnly dropdownIcon look disabled

### DIFF
--- a/lib/src/judo_combobox.dart
+++ b/lib/src/judo_combobox.dart
@@ -71,7 +71,7 @@ class _JudoComboBoxState<T> extends State<JudoComboBox<T>> {
               child: DropdownButtonFormField<T>(
                 iconDisabledColor: widget.errorMessage != null ? Theme.of(context).errorColor : Theme.of(context).disabledColor,
                 iconEnabledColor: widget.errorMessage != null ? Theme.of(context).errorColor :
-                  Theme.of(context).unselectedWidgetColor,
+                  Theme.of(context).colorScheme.secondary,
                 decoration: JudoComponentCustomizer.get().getInputComboboxDecoration(theme, widget.label, widget.icon, null, widget.mandatory, widget.disabled, widget.readOnly, widget.errorMessage),
                 onTap: !widget.disabled && !widget.readOnly ? widget.onTap : null,
                 value: widget.value,

--- a/lib/src/judo_combobox.dart
+++ b/lib/src/judo_combobox.dart
@@ -69,9 +69,7 @@ class _JudoComboBoxState<T> extends State<JudoComboBox<T>> {
         child: Container(
           decoration: widget.errorMessage != null ? null : JudoComponentCustomizer.get().getInputBoxCustomizer(theme, widget.disabled, widget.readOnly),
               child: DropdownButtonFormField<T>(
-                iconDisabledColor: widget.errorMessage != null ? Theme.of(context).errorColor :
-                  widget.disabled ? Theme.of(context).disabledColor :
-                    Theme.of(context).unselectedWidgetColor,
+                iconDisabledColor: widget.errorMessage != null ? Theme.of(context).errorColor : Theme.of(context).disabledColor,
                 iconEnabledColor: widget.errorMessage != null ? Theme.of(context).errorColor :
                   Theme.of(context).unselectedWidgetColor,
                 decoration: JudoComponentCustomizer.get().getInputComboboxDecoration(theme, widget.label, widget.icon, null, widget.mandatory, widget.disabled, widget.readOnly, widget.errorMessage),

--- a/lib/src/judo_theme_customizer.dart
+++ b/lib/src/judo_theme_customizer.dart
@@ -285,21 +285,23 @@ class DefaultJudoComponentsCustomizer implements JudoComponentCustomizer {
   @override
   ThemeData getSwitchThemeData(
       ThemeData theme, bool disabled, bool readOnly, String errorMessage) {
-    return disabled
-        ? theme.copyWith(
-            checkboxTheme: theme.checkboxTheme.copyWith(
-              fillColor: MaterialStateProperty.all<Color>(theme.disabledColor),
-              side: BorderSide(width: 2.0, color: theme.disabledColor),
-            ),
-          )
-        : errorMessage != null
-            ? theme.copyWith(
-                checkboxTheme: theme.checkboxTheme.copyWith(
-                  fillColor: MaterialStateProperty.all<Color>(theme.errorColor),
-                  side: BorderSide(width: 2.0, color: theme.errorColor),
-                ),
-              )
-            : theme;
+    if (errorMessage != null) {
+      return theme.copyWith(
+        checkboxTheme: theme.checkboxTheme.copyWith(
+          fillColor: MaterialStateProperty.all<Color>(theme.errorColor),
+          side: BorderSide(width: 2.0, color: theme.errorColor),
+        ),
+      );
+    }
+    if (disabled || readOnly) {
+      return theme.copyWith(
+        checkboxTheme: theme.checkboxTheme.copyWith(
+          fillColor: MaterialStateProperty.all<Color>(theme.disabledColor),
+          side: BorderSide(width: 2.0, color: theme.disabledColor),
+        ),
+      );
+    }
+    return theme;
   }
 
   @override
@@ -312,7 +314,7 @@ class DefaultJudoComponentsCustomizer implements JudoComponentCustomizer {
         ),
       );
     }
-    if (disabled) {
+    if (disabled || readOnly) {
       return theme.copyWith(
         radioTheme: theme.radioTheme.copyWith(
           fillColor: MaterialStateProperty.all<Color>(theme.disabledColor),


### PR DESCRIPTION
Active combobox:
![Screenshot from 2021-10-14 10-52-19](https://user-images.githubusercontent.com/37060328/137285914-03c4661a-2b1e-468a-a7a1-8c516c007610.png)

ReadOnly combobox:
![Screenshot from 2021-10-14 10-52-37](https://user-images.githubusercontent.com/37060328/137285967-f819e6d3-4520-4ea7-8906-525077844b39.png)

Checkbox and radio button theme is updated based on [JNG-3167](https://blackbelt.atlassian.net/browse/JNG-3167)
Active and readOnly checkboxes:
![Screenshot from 2021-10-14 11-02-38](https://user-images.githubusercontent.com/37060328/137286169-9ad31384-4ae0-45a3-9b16-0087088f7f0d.png)

ReadOnly checkboxes:
![Screenshot from 2021-10-14 11-03-10](https://user-images.githubusercontent.com/37060328/137286239-1d102af9-015e-40fd-886b-53bb4a5b4452.png)

